### PR TITLE
Update className in Html5DashJS.hideErrors

### DIFF
--- a/contrib/videojs/videojs-dash.js
+++ b/contrib/videojs/videojs-dash.js
@@ -126,7 +126,7 @@
    * to reset MediaKeys in resetSrc_
    */
   Html5DashJS.hideErrors = function (el) {
-    el.className += 'vjs-dashjs-hide-errors';
+    el.className += ' vjs-dashjs-hide-errors';
   };
 
   /*


### PR DESCRIPTION
vjs-dashjs-hide-errors currently invalidates other classes as a space is not present in el.className.